### PR TITLE
Remove `Domain is inappropriate based on request URI hostname` error

### DIFF
--- a/lib/cookiejar/cookie_validation.rb
+++ b/lib/cookiejar/cookie_validation.rb
@@ -261,9 +261,9 @@ module CookieJar
       # The request-host is a HDN (not IP address) and has the form HD,
       # where D is the value of the Domain attribute, and H is a string
       # that contains one or more dots.
-      unless domains_match cookie_host, uri
-        errors << 'Domain is inappropriate based on request URI hostname'
-      end
+      #unless domains_match cookie_host, uri
+      #  errors << 'Domain is inappropriate based on request URI hostname'
+      #end
 
       # The Port attribute has a "port-list", and the request-port was
       # not in the list.

--- a/spec/cookie_validation_spec.rb
+++ b/spec/cookie_validation_spec.rb
@@ -31,17 +31,17 @@ describe CookieValidation do
         Cookie.from_set_cookie localaddr, 'foo=bar;domain=localhost'
       end).to raise_error InvalidCookieError
     end
-    it 'should fail for mismatched domains' do
+    skip 'should fail for mismatched domains' do
       expect(lambda do
         Cookie.from_set_cookie 'http://www.foo.com/', 'foo=bar;domain=bar.com'
       end).to raise_error InvalidCookieError
     end
-    it 'should fail for domains more than one level up' do
+    skip 'should fail for domains more than one level up' do
       expect(lambda do
         Cookie.from_set_cookie 'http://x.y.z.com/', 'foo=bar;domain=z.com'
       end).to raise_error InvalidCookieError
     end
-    it 'should fail for setting subdomain cookies' do
+    skip 'should fail for setting subdomain cookies' do
       expect(lambda do
         Cookie.from_set_cookie 'http://foo.com/', 'foo=bar;domain=auth.foo.com'
       end).to raise_error InvalidCookieError

--- a/spec/jar_spec.rb
+++ b/spec/jar_spec.rb
@@ -183,7 +183,7 @@ describe Jar do
         cookie.name == 'foo'
       end.version).to eq 1
     end
-    it 'should silently drop invalid cookies' do
+    skip 'should silently drop invalid cookies' do
       jar = Jar.new
       cookies = jar.set_cookies_from_headers 'http://localhost/',
                                              'Set-Cookie' => ['foo=bar', 'bar=baz;domain=.foo.com']


### PR DESCRIPTION
Remove `Domain is inappropriate based on request URI hostname` error in order to fix compatibility with the latest Salesforce API